### PR TITLE
Create workflow_enforcer.yaml to protect non release PR to main

### DIFF
--- a/.github/workflows/workflow_enforcer.yaml
+++ b/.github/workflows/workflow_enforcer.yaml
@@ -1,0 +1,15 @@
+# obtained from https://stackoverflow.com/a/75414339
+name: 'Check Branch'
+
+on:
+  pull_request:
+
+jobs:
+  check_branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch
+        if: github.base_ref == 'main' && !startsWith(github.head_ref, 'release/')
+        run: |
+          echo "ERROR: You can only merge into main from a release branch."
+          exit 1


### PR DESCRIPTION
Checks if compare branch is not release, if so: spits an error